### PR TITLE
Add mise lazy-install stub for zsh and fish

### DIFF
--- a/bin/install-mise
+++ b/bin/install-mise
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+curl https://mise.run | sh

--- a/fish/conf.d/stubs.fish
+++ b/fish/conf.d/stubs.fish
@@ -1,0 +1,9 @@
+function mise
+    set file $HOME/.local/bin/mise
+
+    if not test -x $file
+        $HOME/.config/bin/install-mise
+    end
+
+    $file $argv
+end

--- a/zsh/console.sh
+++ b/zsh/console.sh
@@ -96,6 +96,16 @@ nvm() {
     nvm $@
 }
 
+mise() {
+    file="$HOME/.local/bin/mise"
+
+    if [ ! -x $file ]; then
+        "$HOME/.config/bin/install-mise"
+    fi
+
+    $file $@
+}
+
 nvim() {
     file="$HOME/sbin/nvim"
 


### PR DESCRIPTION
## Changes

- `bin/install-mise` — shared installer script (`curl https://mise.run | sh`)
- `zsh/console.sh` — `mise()` stub, installs on first use, follows existing nvim/kubectl pattern
- `fish/conf.d/stubs.fish` — fish equivalent, calls the same install script

## How it works

First call to `mise` in either shell checks for `~/.local/bin/mise`, runs `bin/install-mise` if missing, then delegates to the real binary. Subsequent calls go straight to the binary.

`stubs.fish` is a new file to hold fish lazy-install stubs going forward, parallel to the zsh pattern in `console.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic installation and lazy-loading of mise for Fish and Zsh shell environments. The tool installs on first use, ensuring it's always available when invoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->